### PR TITLE
Mark `FEATURE_PROTO3_OPTIONAL` as supported

### DIFF
--- a/lib/rpc_proto_gen_helpers.ex
+++ b/lib/rpc_proto_gen_helpers.ex
@@ -1,18 +1,2 @@
 defmodule RPCProtoGenHelpers do
-  @moduledoc """
-  Documentation for `RPCProtoGenHelpers`.
-  """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> RPCProtoGenHelpers.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/lib/rpc_proto_gen_helpers/cli.ex
+++ b/lib/rpc_proto_gen_helpers/cli.ex
@@ -68,7 +68,10 @@ defmodule RPCProtoGenHelpers.CLI do
         ]
       end)
 
-    response = Google.Protobuf.Compiler.CodeGeneratorResponse.new(file: files)
+    response = Google.Protobuf.Compiler.CodeGeneratorResponse.new(
+      file: files,
+      supported_features: Google.Protobuf.Compiler.CodeGeneratorResponse.Feature.value(:FEATURE_PROTO3_OPTIONAL)
+    )
 
     IO.binwrite(Protobuf.Encoder.encode(response))
   end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule RPCProtoGenHelpers.MixProject do
   defp deps do
     [
       {:recase, "~> 0.7.0"},
-      {:protobuf, "~> 0.7.1"}
+      {:protobuf, "~> 0.14.0"}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "protobuf": {:hex, :protobuf, "0.7.1", "7d1b9f7d9ecb32eccd96b0c58572de4d1c09e9e3bc414e4cb15c2dce7013f195", [:mix], [], "hexpm", "6eff7a5287963719521c82e5d5b4583fd1d7cdd89ad129f0ea7d503a50a4d13f"},
+  "protobuf": {:hex, :protobuf, "0.14.0", "75b64b8c1f0c833b5e76cd841d3448f077f655c2a2eed53358651fbfe4a6b70e", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm", "0f747eaa54ace9617536f1cb4b2a4962bc7e43f1aa475c6fa9c60079955c4cb0"},
   "recase": {:hex, :recase, "0.7.0", "3f2f719f0886c7a3b7fe469058ec539cb7bbe0023604ae3bce920e186305e5ae", [:mix], [], "hexpm", "36f5756a9f552f4a94b54a695870e32f4e72d5fad9c25e61bc4a3151c08a4e0c"},
 }

--- a/test/rpc_proto_gen_helpers_test.exs
+++ b/test/rpc_proto_gen_helpers_test.exs
@@ -1,8 +1,0 @@
-defmodule RPCProtoGenHelpersTest do
-  use ExUnit.Case
-  doctest RPCProtoGenHelpers
-
-  test "greets the world" do
-    assert RPCProtoGenHelpers.hello() == :world
-  end
-end


### PR DESCRIPTION
We don't need to do anything to support this option, as we don't rely on
any specific field options in this generator, therefore we support this
feature by default.

This avoids warnings being emitted during generation for protos which
use `optional` fields.